### PR TITLE
fix(for): 修复示例中的死循环

### DIFF
--- a/src/essential/base/55.loop.md
+++ b/src/essential/base/55.loop.md
@@ -50,8 +50,8 @@ func main() {
 可以同时初始化多个变量，但是不能有多个`post statement`
 
 ```go
-for i, j := 1, 2; i < 100 || j < 1000; i++ {
-   fmt.Println(i, j)
+for i, j := 1, 2; i < 100 && j < 1000; i++ {
+	fmt.Println(i, j)
 }
 ```
 


### PR DESCRIPTION
![70c358b95de231473868379027049a3b](https://github.com/CQUT-Programmer/Golang-Doc/assets/19829513/b2c279d6-b806-4e9b-801a-e3e544725407)

页面中 输出 20以内的数字示例语法错误，多变量循环是一个死循环。